### PR TITLE
Add XL_SCT env var

### DIFF
--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -130,6 +130,7 @@ impl LaunchCommand {
         println!("XLCM: Starting XIVLauncher");
         let cmd = Command::new(self.install_directory.join("XIVLauncher.Core"))
             .env("XL_PRELOAD", env::var("LD_PRELOAD").unwrap_or_default()) // Write XL_PRELOAD so it can maybe be passed to the game later.
+            .env("XL_SCT", "1") // Needed to trigger compatibility tool mode in XIVLauncher. Otherwise XL_PRELOAD will be ignored.
             .env(
                 "OPENSSL_CONF",
                 &self.install_directory.join("openssl_fix.cnf"),


### PR DESCRIPTION
Need to set XL_SCT to properly trigger compatibility tool mode in XIVLauncher-RB. I've add a PR for XIVLauncher.Core here: https://github.com/goatcorp/XIVLauncher.Core/pull/158